### PR TITLE
Enable es6 modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(source_files
 add_definitions(-DHAVE_CONFIG_H)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
   -s MODULARIZE=1 \
+  -s EXPORT_ES6=1 \
   -s SINGLE_FILE=1 \
   -s EXPORT_NAME=aubio \
   -Oz --closure 1 --bind")


### PR DESCRIPTION
Change output to be es6 module to make aubiojs importable in Audio Worklets. 
In particular it would allow to port https://github.com/qiuxiang/tuner from deprecated script processor to modern audio worklets.